### PR TITLE
Nickname spelling correction

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "license": "GPL-2.0",
     "url": "https://code.launchpad.net/mailman",
     "maintainer": {
-        "name": "Alex Aubin",
+        "name": "alexAubin",
         "email": "alex.aubin@mailoo.org",
         "url": "https://github.com/alexAubin/"
     },


### PR DESCRIPTION
only package using "Alex Aubin" instead of "alexAubin"